### PR TITLE
Env lock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,5 @@ toml = "0.5"
 web3 = "0.8"
 
 [dev-dependencies]
-ureq = "0.11"
 tempfile = "3"
+ureq = "0.11"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,3 +30,4 @@ web3 = "0.8"
 
 [dev-dependencies]
 ureq = "0.11"
+tempfile = "3"

--- a/src/docker/bitcoin.rs
+++ b/src/docker/bitcoin.rs
@@ -112,7 +112,6 @@ mod tests {
     use super::*;
     use crate::docker::Node;
     use crate::docker::NodeImage;
-    use envfile::EnvFile;
     use rust_bitcoin::{Address, TxOut};
     use std::convert::TryFrom;
 
@@ -170,11 +169,9 @@ mod tests {
     fn can_get_rpc_port_from_envfile() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
         runtime.block_on(Node::<BitcoinNode>::start()).unwrap();
 
-        let envfile = EnvFile::new(&file.path()).unwrap();
+        let envfile = crate::env_file::new().unwrap();
         assert!(envfile.get(HTTP_URL_KEY).is_some());
     }
 
@@ -182,11 +179,9 @@ mod tests {
     fn can_get_p2p_port_from_envfile() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
         runtime.block_on(Node::<BitcoinNode>::start()).unwrap();
 
-        let envfile = EnvFile::new(&file.path()).unwrap();
+        let envfile = crate::env_file::new().unwrap();
         assert!(envfile.get(P2P_URI_KEY).is_some());
     }
 }

--- a/src/docker/bitcoin.rs
+++ b/src/docker/bitcoin.rs
@@ -143,11 +143,7 @@ mod tests {
     fn can_ping_bitcoin_node() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
-        let bitcoin = runtime
-            .block_on(Node::<BitcoinNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        let bitcoin = runtime.block_on(Node::<BitcoinNode>::start()).unwrap();
 
         assert!(bitcoin.node_image.rpc_client.ping().is_ok());
     }
@@ -156,11 +152,7 @@ mod tests {
     fn can_fund_bitcoin_address() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
-        let bitcoin = runtime
-            .block_on(Node::<BitcoinNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        let bitcoin = runtime.block_on(Node::<BitcoinNode>::start()).unwrap();
         let client = &bitcoin.node_image.rpc_client;
 
         let address = client.get_new_address(None, None).unwrap();
@@ -180,9 +172,7 @@ mod tests {
 
         let file = tempfile::Builder::new().tempfile().unwrap();
 
-        runtime
-            .block_on(Node::<BitcoinNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        runtime.block_on(Node::<BitcoinNode>::start()).unwrap();
 
         let envfile = EnvFile::new(&file.path()).unwrap();
         assert!(envfile.get(HTTP_URL_KEY).is_some());
@@ -194,9 +184,7 @@ mod tests {
 
         let file = tempfile::Builder::new().tempfile().unwrap();
 
-        runtime
-            .block_on(Node::<BitcoinNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        runtime.block_on(Node::<BitcoinNode>::start()).unwrap();
 
         let envfile = EnvFile::new(&file.path()).unwrap();
         assert!(envfile.get(P2P_URI_KEY).is_some());

--- a/src/docker/ethereum.rs
+++ b/src/docker/ethereum.rs
@@ -110,11 +110,7 @@ mod tests {
     fn can_ping_ethereum_node() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
-        let ethereum = runtime
-            .block_on(Node::<EthereumNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        let ethereum = runtime.block_on(Node::<EthereumNode>::start()).unwrap();
 
         ethereum
             .node_image
@@ -130,11 +126,7 @@ mod tests {
     fn can_fund_ethereum_address() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
-        let ethereum = runtime
-            .block_on(Node::<EthereumNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        let ethereum = runtime.block_on(Node::<EthereumNode>::start()).unwrap();
 
         let address = Address::from_str("98e8183a8bf0b7805ed7eb1044ba3e9eb2ed6c1d").unwrap();
         let value = U256::from(1_000);
@@ -163,9 +155,7 @@ mod tests {
 
         let file = tempfile::Builder::new().tempfile().unwrap();
 
-        runtime
-            .block_on(Node::<EthereumNode>::start(file.path().to_path_buf()))
-            .unwrap();
+        runtime.block_on(Node::<EthereumNode>::start()).unwrap();
 
         let envfile = EnvFile::new(&file.path()).unwrap();
         assert!(envfile.get(&HTTP_URL_KEY).is_some());

--- a/src/docker/ethereum.rs
+++ b/src/docker/ethereum.rs
@@ -102,7 +102,6 @@ pub fn derive_address(secret_key: secp256k1::SecretKey) -> Address {
 mod tests {
     use super::*;
     use crate::docker::Node;
-    use envfile::EnvFile;
     use std::str::FromStr;
     use web3::types::{Address, BlockId, BlockNumber, U128};
 
@@ -153,11 +152,9 @@ mod tests {
     fn can_get_http_port_from_envfile() {
         let mut runtime = tokio::runtime::Runtime::new().unwrap();
 
-        let file = tempfile::Builder::new().tempfile().unwrap();
-
         runtime.block_on(Node::<EthereumNode>::start()).unwrap();
 
-        let envfile = EnvFile::new(&file.path()).unwrap();
+        let envfile = crate::env_file::new().unwrap();
         assert!(envfile.get(&HTTP_URL_KEY).is_some());
     }
 }

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -2,9 +2,10 @@ use envfile::EnvFile;
 use std::fs::File;
 use std::io;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-const LOCK_FILE: &str = ".env.lock";
+const ENV_FILE: &str = ".env";
+const LOCK_FILE_SUFFIX: &str = ".lock";
 const LOCK_FILE_CONTENT: &[u8] =
     b"# This lock file is to ensure that no two create-comit-app updates the .env file.";
 
@@ -19,30 +20,39 @@ pub trait LockUpdateWrite {
     fn lock_update_write(&mut self, key: &str, value: &str) -> Result<(), Error>;
 }
 
-fn lock() -> Result<(), Error> {
-    let lock_path = Path::new(LOCK_FILE);
+fn lock_path(envfile: &EnvFile) -> PathBuf {
+    // TODO: Remove unwrap
+    let mut lock_path = envfile.path.as_os_str().to_str().unwrap().to_string();
+    lock_path.push_str(LOCK_FILE_SUFFIX);
+    Path::new(&lock_path).to_path_buf()
+}
+
+fn lock(envfile: &EnvFile) -> Result<(), Error> {
+    let lock_path = lock_path(envfile);
+
     if lock_path.exists() {
         Err(Error::IsLocked)
     } else {
-        let mut file = File::create(LOCK_FILE)?;
+        let mut file = File::create(lock_path)?;
         file.write_all(LOCK_FILE_CONTENT)?;
         Ok(())
     }
 }
 
-fn unlock() -> Result<(), Error> {
-    std::fs::remove_file(LOCK_FILE).map_err(|e| Error::CannotRemoveLock(e))
+fn unlock(envfile: &EnvFile) -> Result<(), Error> {
+    let lock_path = lock_path(envfile);
+    std::fs::remove_file(lock_path).map_err(|e| Error::CannotRemoveLock(e))
 }
 
 impl LockUpdateWrite for EnvFile {
     fn lock_update_write(&mut self, key: &str, value: &str) -> Result<(), Error> {
-        lock()
+        lock(self)
             .and(
                 self.update(key, value)
                     .write()
                     .map_err(Error::CannotUpdateEnvFile),
             )
-            .and(unlock())
+            .and(unlock(self))
     }
 }
 
@@ -58,13 +68,25 @@ mod tests {
 
     #[test]
     fn can_lock_and_unlock_twice() {
-        let path = tempfile::Builder::new().tempfile().unwrap();
-        let mut env_file = EnvFile::new(path.path()).unwrap();
+        let temp_file = tempfile::Builder::new().suffix(".env").tempfile().unwrap();
+        let mut env_file = EnvFile::new(temp_file.path()).unwrap();
 
         let res = env_file.lock_update_write("key", "value");
         assert!(res.is_ok());
 
         let res = env_file.lock_update_write("key", "value");
         assert!(res.is_ok());
+    }
+
+    #[test]
+    fn cannot_lock() {
+        let temp_file = tempfile::Builder::new().suffix(".env").tempfile().unwrap();
+        let mut env_file = EnvFile::new(temp_file.path()).unwrap();
+
+        let mut lock_file = File::create(lock_path(&env_file)).unwrap();
+        lock_file.write_all(b"").unwrap();
+
+        let res = env_file.lock_update_write("key", "value");
+        assert!(res.is_err());
     }
 }

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -57,12 +57,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn can_lock_and_unlock() {
+    fn can_lock_and_unlock_twice() {
         let path = tempfile::Builder::new().tempfile().unwrap();
         let mut env_file = EnvFile::new(path.path()).unwrap();
 
         let res = env_file.lock_update_write("key", "value");
+        assert!(res.is_ok());
 
-        assert!(res.is_ok())
+        let res = env_file.lock_update_write("key", "value");
+        assert!(res.is_ok());
     }
 }

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -1,0 +1,68 @@
+use envfile::EnvFile;
+use std::fs::File;
+use std::io;
+use std::io::Write;
+use std::path::Path;
+
+const LOCK_FILE: &str = ".env.lock";
+const LOCK_FILE_CONTENT: &[u8] =
+    b"# This lock file is to ensure that no two create-comit-app updates the .env file.";
+
+pub enum Error {
+    IsLocked,
+    CannotWriteLock(io::Error),
+    CannotRemoveLock(io::Error),
+    CannotUpdateEnvFile(io::Error),
+}
+
+pub trait LockUpdateWrite {
+    fn lock_update_write(&mut self, key: &str, value: &str) -> Result<(), Error>;
+}
+
+fn lock() -> Result<(), Error> {
+    let lock_path = Path::new(LOCK_FILE);
+    if lock_path.exists() {
+        Err(Error::IsLocked)
+    } else {
+        let mut file = File::create(LOCK_FILE)?;
+        file.write_all(LOCK_FILE_CONTENT)?;
+        Ok(())
+    }
+}
+
+fn unlock() -> Result<(), Error> {
+    std::fs::remove_file(LOCK_FILE).map_err(|e| Error::CannotRemoveLock(e))
+}
+
+impl LockUpdateWrite for EnvFile {
+    fn lock_update_write(&mut self, key: &str, value: &str) -> Result<(), Error> {
+        lock()
+            .and(
+                self.update(key, value)
+                    .write()
+                    .map_err(Error::CannotUpdateEnvFile),
+            )
+            .and(unlock())
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(io_error: io::Error) -> Self {
+        Error::CannotWriteLock(io_error)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_lock_and_unlock() {
+        let path = tempfile::Builder::new().tempfile().unwrap();
+        let mut env_file = EnvFile::new(path.path()).unwrap();
+
+        let res = env_file.lock_update_write("key", "value");
+
+        assert!(res.is_ok())
+    }
+}

--- a/src/env_file.rs
+++ b/src/env_file.rs
@@ -43,7 +43,7 @@ fn lock(envfile: &EnvFile) -> Result<(), Error> {
 
 fn unlock(envfile: &EnvFile) -> Result<(), Error> {
     let lock_path = lock_path(envfile);
-    std::fs::remove_file(lock_path).map_err( Error::CannotRemoveLock)
+    std::fs::remove_file(lock_path).map_err(Error::CannotRemoveLock)
 }
 
 pub fn create() -> Result<File, io::Error> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod create_comit_app;
 pub mod docker;
+pub mod env_file;
 pub mod executable;
 pub mod new;
 pub mod start_env;


### PR DESCRIPTION
Explicitly fails if 2 different threads try to write in the `.env` file at the same time.

If there is actual failures when using create-comit-app then the next improvement would be to only have the main write in the env file and all modules bubble up the information.