### PR TITLE
Prepare for hello-swap to use env file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,6 +159,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "byte-tools"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,12 +285,12 @@ version = "0.1.0"
 dependencies = [
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoincore-rpc 0.8.0-rc1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "envfile 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hdwallet 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex-serde 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "port_check 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2664,6 +2669,7 @@ dependencies = [
 "checksum bitflags 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3d155346769a6855b86399e9bc3814ab343cd3d62c7e985113d46a0ec3c281fd"
 "checksum block-buffer 0.7.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
 "checksum block-padding 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6d4dc3af3ee2e12f3e5d224e5e1e3d73668abbeb69e566d361f7d5563a4fdf09"
+"checksum bs58 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b170cd256a3f9fa6b9edae3e44a7dfdfc77e8124dbc3e2612d75f9c3e2396dae"
 "checksum byte-tools 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 "checksum byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a7c3dd8985a7111efc5c80b44e23ecdd8c007de8ade3b96595387e812b957cf5"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,12 +6,12 @@ edition = "2018"
 
 [dependencies]
 bitcoincore-rpc = "0.8.0-rc1"
+bs58 = "0.3"
 config = { version = "0.9", features = ["toml"] }
 envfile = "0.2"
 futures = "0.1"
 git2 = "0.10.1"
 hdwallet = "0.2"
-hex = "0.3"
 hex-serde = "0.1.0"
 port_check = "0.1"
 rand = "0.7"

--- a/src/start_env.rs
+++ b/src/start_env.rs
@@ -1,8 +1,8 @@
 use crate::docker::bitcoin::{self, BitcoinNode};
 use crate::docker::ethereum::{self, EthereumNode};
 use crate::docker::{Node, NodeImage};
-use crate::executable::btsieve::{self};
-use crate::executable::cnd::{self};
+use crate::executable::btsieve;
+use crate::executable::cnd;
 use crate::executable::Executable;
 use envfile::EnvFile;
 use futures;
@@ -98,14 +98,14 @@ pub fn start_env() {
     for (i, hd_key) in bitcoin_hd_keys.iter().enumerate() {
         envfile.update(
             format!("BITCOIN_HD_KEY_{}", i).as_str(),
-            hex::encode(&hd_key.serialize()).as_str(),
+            &bs58::encode(&hd_key.serialize()).into_string(),
         );
     }
 
     for (i, hd_key) in ethereum_hd_keys.iter().enumerate() {
         envfile.update(
             format!("ETHEREUM_HD_KEY_{}", i).as_str(),
-            hex::encode(&hd_key.serialize()).as_str(),
+            &bs58::encode(&hd_key.serialize()).into_string(),
         );
     }
     envfile.write().unwrap();

--- a/src/start_env.rs
+++ b/src/start_env.rs
@@ -110,7 +110,7 @@ pub fn start_env() {
     }
     envfile.write().unwrap();
 
-    for i in 1..3 {
+    for i in 0..2 {
         let port_bind = port_check::free_local_port().unwrap();
         let settings = btsieve::Settings {
             http_api: btsieve::HttpApi {
@@ -156,7 +156,7 @@ pub fn start_env() {
 
     println!("Two btsieves up and running");
 
-    for i in 1..3 {
+    for i in 0..2 {
         let btsieve_port = envfile
             .get(format!("{}_{}", HTTP_PORT_BTSIEVE, i).as_str())
             .expect("could not find var in envfile");


### PR DESCRIPTION
- Use zero-based numbering for all environment variables, so that reading these environment variables is predictable in hello-swap.
- Use base58 encoding for the HD keys, since the bcoin and ethers wallets expect a base58 encoded HD key. Unfortunately, instantiating an ethers wallet using one of the generated HD keys fails with:

```
UnhandledPromiseRejectionWarning: Error: invalid extended key (argument="extendedKey", value="[REDACTED]", version=4.0.37)
```

I recommend trying to use mnemonic's instead, since both the bcoin and ethers wallets can be instantiated using them. The difficulty there would be to derive addresses to fund in Rust. I would probably have a look at [wagyu](https://github.com/ArgusHQ/wagyu), although I had problems using it in the past (which is why I went for [hdwallet](https://github.com/jjyr/hdwallet) instead).

Fixes comit-network/comit-rs#1335.