### PR TITLE
Simplify readme by moving hard-setup to appendix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,14 @@
 
 Set up a local development environment for COMIT apps with one command. 
 
-## Install
-
-### The Easy Way
+## 1 - Install
 
 1. Install Docker,
 2. Install yarn or npm, 
 3. Go get the latest [release](https://github.com/comit-network/create-comit-app/releases) for your platform,
 4. Unzip & done!
 
-### The Hard Way
-
-Swedish style, build it yourself.
-
-1. Install Docker,
-2. Install Rust: `curl https://sh.rustup.rs -sSf | sh`,
-3. Checkout the repo: `git clone https://github.com/comit-network/create-comit-app/`,
-4. Build and install: ` cargo install --path create-comit-app`.
-
-## Profit!
+## 2 - Create your first project!
 
  1. Create a new COMIT app project: `./create-comit-app new my-cool-app`,
 2. `cd my-cool-app`,
@@ -30,3 +19,15 @@ Swedish style, build it yourself.
    - Install dependencies: `yarn install` (or `npm install`),
    - Run the [hello-swap](https://github.com/comit-network/hello-swap/) example: `yarn start` (or `npm start`),
    - Hit `CTRL-C` once the swap is done.
+   
+
+# Appendix
+
+Important: You don't have to follow this section, the above section is actually sufficient.
+
+## Appendix A: Build the project yourself
+
+1. Install Docker,
+2. Install Rust: `curl https://sh.rustup.rs -sSf | sh`,
+3. Checkout the repo: `git clone https://github.com/comit-network/create-comit-app/`,
+4. Build and install: ` cargo install --path create-comit-app`.


### PR DESCRIPTION
Several participants in the workshop just blindly followed the instructions in order. 
Consequently they did `simple setup` and `hard` setup...

In order to avoid this I'd suggest we move the `hard setup` section to an appendix. Or we just remove it completely. This is a PR to move it to an appendix. 

Feel free to adapt this. I'm not sure what the best solution is yet. 