### PR TITLE
Lazily pull docker images

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,4 +2,5 @@ pub mod cnd_settings;
 pub mod create_comit_app;
 pub mod docker;
 pub mod new;
+pub mod print_progress;
 pub mod start_env;

--- a/src/print_progress.rs
+++ b/src/print_progress.rs
@@ -1,0 +1,8 @@
+#[macro_export]
+macro_rules! print_progress {
+    ($($arg:tt)*) => ({
+        print!($($arg)*);
+        print!("...");
+        std::io::stdout().flush().ok().expect("Could not flush stdout");
+    })
+}

--- a/src/start_env/mod.rs
+++ b/src/start_env/mod.rs
@@ -4,6 +4,7 @@ use crate::docker::delete_container;
 use crate::docker::ethereum::{self, EthereumNode};
 use crate::docker::Cnd;
 use crate::docker::{blockchain::BlockchainImage, create_network, delete_network, Node};
+use crate::print_progress;
 use bitcoincore_rpc::RpcApi;
 use envfile::EnvFile;
 use futures;
@@ -25,14 +26,6 @@ use tokio::timer::Interval;
 use web3::types::U256;
 
 mod temp_fs;
-
-macro_rules! print_progress {
-    ($($arg:tt)*) => ({
-        print!($($arg)*);
-        print!("...");
-        std::io::stdout().flush().ok().expect("Could not flush stdout");
-    })
-}
 
 pub fn start_env() {
     let mut runtime = Runtime::new().expect("Could not get runtime");


### PR DESCRIPTION
Resolves #54.

First time doing `start-env`:
```
Creating Docker network (create-comit-app)...✓
Starting Bitcoin node...Downloading coblox/bitcoin-core:0.17.0...✓
Starting Ethereum node...Downloading parity/parity:v2.5.0...✓
Writing configuration in env file...✓
Starting two cnds...Downloading comitnetwork/cnd:0.3.0...✓
🎉 Environment is ready, time to create a COMIT app!
```

The other times:
```
Creating Docker network (create-comit-app)...✓
Starting Bitcoin node...✓
Starting Ethereum node...✓
Writing configuration in env file...✓
Starting two cnds...✓
🎉 Environment is ready, time to create a COMIT app!
```