### PR TITLE
Use round decimal number for initial Ether funding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Changed
+- Fix the odd initial Ether amount .
+
 ## 0.2.0 - 2019-10-04
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Fix the odd initial Ether amount .
+- Fix the odd initial Ether amount.
 
 ## 0.2.0 - 2019-10-04
 

--- a/src/start_env/mod.rs
+++ b/src/start_env/mod.rs
@@ -293,7 +293,7 @@ fn start_ethereum_node(
                 node.node_image
                     .fund(
                         ethereum::derive_address(key),
-                        U256::from(9_000_000_000_000_000_000u128),
+                        U256::from(9u128*10u128.pow(18)),
                     )
                     .map_err(Error::EtherFunding)
                     .map(|_| node)

--- a/src/start_env/mod.rs
+++ b/src/start_env/mod.rs
@@ -293,7 +293,7 @@ fn start_ethereum_node(
                 node.node_image
                     .fund(
                         ethereum::derive_address(key),
-                        U256::from("9000000000000000000"),
+                        U256::from("7CE66C50E2840000"), // 9_000_000_000_000_000_000: 9 Ethers
                     )
                     .map_err(Error::EtherFunding)
                     .map(|_| node)

--- a/src/start_env/mod.rs
+++ b/src/start_env/mod.rs
@@ -293,7 +293,7 @@ fn start_ethereum_node(
                 node.node_image
                     .fund(
                         ethereum::derive_address(key),
-                        U256::from(9u128*10u128.pow(18)),
+                        U256::from(100u128*10u128.pow(18)),
                     )
                     .map_err(Error::EtherFunding)
                     .map(|_| node)

--- a/src/start_env/mod.rs
+++ b/src/start_env/mod.rs
@@ -293,7 +293,7 @@ fn start_ethereum_node(
                 node.node_image
                     .fund(
                         ethereum::derive_address(key),
-                        U256::from("7CE66C50E2840000"), // 9_000_000_000_000_000_000: 9 Ethers
+                        U256::from(9_000_000_000_000_000_000u128),
                     )
                     .map_err(Error::EtherFunding)
                     .map(|_| node)


### PR DESCRIPTION
```
[maker] Bitcoin balance: 10. Ether balance: 9
[taker] Bitcoin balance: 10. Ether balance: 9
```

I used a hex string because 9 Ether is bigger than `u64` and I did not see the point adding `BigUint` boilerplate code for one funding.