### PR TITLE
Reset readme to describe setup without release on npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,14 @@ Set up a local development environment for COMIT apps with one command.
 1. Install Docker,
 2. Install yarn or npm, 
 3. Download and unzip the latest [release](https://github.com/comit-network/create-comit-app/releases) (`zip` or `tar.gz`)
+4. Add the `create-comit-app` binary to `$PATH`
 
 ## 2 - Create your first project!
 
-1. Copy the `create-comit-app` binary to the folder where the example app should be created.
-2. Create [hello-swap](https://github.com/comit-network/hello-swap/) app: `./create-comit-app new hello-swap`,
-
-## 3 - Run your first project!
-
-1. Start environment (blockchain nodes and COMIT nodes):
-    1. Open terminal and navigate to the directory with the `create-comit-app` binary
-    2. Start local blockchain nodes & COMIT nodes: `./create-comit-app start-env`,
-2. Run hello-swap:
-    1. Open terminal and navigate to the example app directory `cd <path-to-hello-swap>`
+1. Create [hello-swap](https://github.com/comit-network/hello-swap/) app: `create-comit-app new hello-swap`,
+2. Start environment (blockchain nodes and COMIT nodes): `create-comit-app start-env`
+3. Run hello-swap (in separate terminal):
+    1. Navigate to the example app directory `cd <path-to-hello-swap>`
     2. `yarn install` (or `npm install`) to install dependencies
     3. `yarn start` (or `npm start`) to run the application
 

--- a/README.md
+++ b/README.md
@@ -6,19 +6,22 @@ Set up a local development environment for COMIT apps with one command.
 
 1. Install Docker,
 2. Install yarn or npm, 
-3. Run `yarn create comit-app` to install globally (or `npx create-comit-app` to keep it local).
-
+3. Download and unzip the latest [release](https://github.com/comit-network/create-comit-app/releases) (`zip` or `tar.gz`)
 
 ## 2 - Create your first project!
 
-1. Start local blockchain nodes & COMIT nodes: `create-comit-app start-env` (or `npx create-comit-app start-env`), 
-2. Create a new COMIT app project: `create-comit-app new my-cool-app` (or `npx create-comit-app new my-cool-app`),
-3. Open a new terminal:
-   - `cd <path-to-my-cool-app>`,
-   - Install dependencies: `yarn install` (or `npm install`),
-   - Run the [hello-swap](https://github.com/comit-network/hello-swap/) example: `yarn start` (or `npm start`),
-   - Hit `CTRL-C` once the swap is done.
-   
+1. Copy the `create-comit-app` binary to the folder where the example app should be created.
+2. Create [hello-swap](https://github.com/comit-network/hello-swap/) app: `./create-comit-app new hello-swap`,
+
+## 3 - Run your first project!
+
+1. Start environment (blockchain nodes and COMIT nodes):
+    1. Open terminal and navigate to the directory with the `create-comit-app` binary
+    2. Start local blockchain nodes & COMIT nodes: `./create-comit-app start-env`,
+2. Run hello-swap:
+    1. Open terminal and navigate to the example app directory `cd <path-to-hello-swap>`
+    2. `yarn install` (or `npm install`) to install dependencies
+    3. `yarn start` (or `npm start`) to run the application
 
 # Appendix
 


### PR DESCRIPTION
Since the release is not working properly yet the readme is reset to
describe downloading the release and running it. Once the release works
properly though `yarn create`/`npx` the readme will change.

Note that the readme is split into creating and running the example, and
the run section is split into environment and application.
I tried to make the previous description more structured but am not totally convinced that it is better (similar complexity...).