### PR TITLE
Fix build from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,5 +26,5 @@ Important: You don't have to follow this section, the above section is actually 
 
 1. Install Docker,
 2. Install Rust: `curl https://sh.rustup.rs -sSf | sh`,
-3. Checkout the repo: `git clone https://github.com/comit-network/create-comit-app/`,
-4. Build and install: `cargo install --path create-comit-app`.
+3. Checkout the repo: `git clone https://github.com/comit-network/create-comit-app/; cd create-comit-app`,
+4. Build and install: `cargo install --path . create-comit-app`.


### PR DESCRIPTION
Currently the command to install create-comit-app from source is not
correct, it is missing a period.  Add explicit change directory command
also.