### PR TITLE
Generate bitcoin blocks every second

### DIFF
--- a/src/start_env/mod.rs
+++ b/src/start_env/mod.rs
@@ -66,7 +66,7 @@ pub fn start_env() {
 fn bitcoin_generate_blocks(
     bitcoin_node: Arc<Node<BitcoinNode>>,
 ) -> impl Future<Item = (), Error = ()> {
-    Interval::new_interval(Duration::from_secs(2))
+    Interval::new_interval(Duration::from_secs(1))
         .map_err(|_| eprintln!("Issue getting an interval."))
         .for_each({
             let bitcoin_node = bitcoin_node.clone();


### PR DESCRIPTION
Resolves comit-network/hello-swap#43 because the check interval is every 2 seconds.
If a block was generated every 2 seconds and the check was done every 2 seconds then there was chances for the redeem transaction to be sent but not seen (because not yet mined) by the following check.

Generating faster than checking will ensure that.