### PR TITLE
Remove license check from required status

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,6 +1,5 @@
 status = [
     "ci/circleci: build_test",
-    "ci/circleci: static_analysis",
-    "license/cla"
+    "ci/circleci: static_analysis"
 ]
 pr_status = ["license/cla"]


### PR DESCRIPTION
This one isn't running on PRs, so bors always times out.