### PR TITLE
erc20-btc example readme

### DIFF
--- a/new_project/examples/erc20_btc/README.md
+++ b/new_project/examples/erc20_btc/README.md
@@ -1,0 +1,13 @@
+# Example for swapping Bitcoin for ERC20
+
+An example project that shows how to swap Bitcoin for ERC20 tokens with COMIT.
+This example helps to understand the ERC20 setup.
+Both maker and taker are processed in the same terminal.
+
+## How to run this example
+
+1. Make sure you have an environment setup through `create-comit-app`, 
+2. Run `yarn install` to install the necessary dependencies,
+3. Run `yarn start` to start the swap.
+4. Press `Enter` when asked to continue,
+5. Profit!


### PR DESCRIPTION
README for this example was missing. Created in similar form as for the separate-apps example. 