### PR TITLE
Make unix-socket of shiplift a default feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -957,6 +957,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperlocal"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "idna"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1966,6 +1979,7 @@ dependencies = [
  "futures 0.1.29 (registry+https://github.com/rust-lang/crates.io-index)",
  "http 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyperlocal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.103 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2786,6 +2800,7 @@ dependencies = [
 "checksum httparse 1.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
 "checksum hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)" = "34a590ca09d341e94cddf8e5af0bbccde205d5fbc2fa3c09dd67c7f85cea59d7"
 "checksum hyper 0.12.35 (registry+https://github.com/rust-lang/crates.io-index)" = "9dbe6ed1438e1f8ad955a4701e9a944938e9519f6888d12d8558b645e247d5f6"
+"checksum hyperlocal 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d063d6d5658623c6ef16f452e11437c0e7e23a6d327470573fe78892dafbc4fb"
 "checksum idna 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "38f09e0f0b1fb55fdee1f17470ad800da77af5186a1a76c026b679358b7e844e"
 "checksum idna 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
 "checksum ignore 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)" = "0ec16832258409d571aaef8273f3c3cc5b060d784e159d1a0f3b0017308f84a7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ tokio = "0.1"
 toml = "0.5"
 web3 = { version = "0.8", default-features = false, features = ["http"] }
 
+[features]
+default = ["shiplift/unix-socket"]
+
 [build-dependencies]
 anyhow = "1.0.23"
 flate2 = "1.0.13"

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ CARGO_NIGHTLY = $(RUSTUP) run --install $(NIGHTLY_TOOLCHAIN) cargo --color alway
 ifeq ($(OS),Windows_NT)
     BUILD_ARGS := --no-default-features
     TEST_ARGS := --no-default-features
+    INSTALL_ARGS := --no-default-features
 endif
 
 build: build_debug
@@ -35,7 +36,7 @@ install_tomlfmt: install_rust
 ## User install
 
 install:
-	$(CARGO) install --force --path .
+	$(CARGO) install --force --path . $(INSTALL_ARGS)
 
 clean:
 	$(CARGO) clean

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ CARGO = $(RUSTUP) run --install $(TOOLCHAIN) cargo --color always
 NIGHTLY_TOOLCHAIN = "nightly-2019-07-31"
 CARGO_NIGHTLY = $(RUSTUP) run --install $(NIGHTLY_TOOLCHAIN) cargo --color always
 
-ifneq ($(OS),Windows_NT)
-    BUILD_ARGS := --features shiplift/unix-socket
+# cannot use the unix-socket to talk to the docker daemon on windows
+ifeq ($(OS),Windows_NT)
+    BUILD_ARGS := --no-default-features
+    TEST_ARGS := --no-default-features
 endif
 
 build: build_debug
@@ -55,7 +57,7 @@ clippy: install_clippy
 	$(CARGO) clippy --all-targets -- -D warnings
 
 test:
-	$(CARGO) test --all
+	$(CARGO) test --all $(TEST_ARGS)
 
 doc:
 	$(CARGO) doc


### PR DESCRIPTION
This allows the use of `cargo` on *nix systems without having to pass any additional features.