### PR TITLE
Ensure CLA is sorted before telling bors to merge

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -6,6 +6,7 @@ pull_request_rules:
       - "status-success=build (windows)"
       - "status-success=build (ubuntu)"
       - "status-success=e2e_test"
+      - "status-success=license/cla"
       - "author:dependabot-preview[bot]"
     actions:
       comment:


### PR DESCRIPTION
Even if the CLA does not require signatures for dependabot it still needs to mark the PR as OK which may not happen if the service is down.

Here we ensure that mergify does not tell bors to act until the CLA is marked ok as bors/github will stop the merge otherwise.