### PR TITLE
maker sleeps before retrieving Ethereum balance after swap

### DIFF
--- a/new_project/examples/separate_apps/src/lib.ts
+++ b/new_project/examples/separate_apps/src/lib.ts
@@ -38,3 +38,7 @@ export function checkEnvFile(path: string) {
         process.exit(1);
     }
 }
+
+export async function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/new_project/examples/separate_apps/src/maker.ts
+++ b/new_project/examples/separate_apps/src/maker.ts
@@ -3,7 +3,7 @@ import { formatEther } from "ethers/utils";
 import moment from "moment";
 import readLineSync from "readline-sync";
 import { toBitcoin } from "satoshi-bitcoin-ts";
-import { createActor } from "./lib";
+import { createActor, sleep } from "./lib";
 
 /**
  * This executable function represents the maker side during a trade.
@@ -23,7 +23,7 @@ import { createActor } from "./lib";
 
     // print balances before swapping
     console.log(
-        "[Maker] Bitcoin balance: %f. Ether balance: %f",
+        "[Maker] Bitcoin balance: %f, Ether balance: %f",
         parseFloat(await maker.bitcoinWallet.getBalance()).toFixed(2),
         parseFloat(
             formatEther(await maker.ethereumWallet.getBalance())
@@ -164,9 +164,15 @@ import { createActor } from "./lib";
 
     console.log("Swapped!");
 
+    // The comit network daemon (cnd) processes new incoming blocks faster than etherjs.
+    // This results in the final balance not being printed correctly, even though the redeem transaction was already
+    // noticed by cnd.
+    // In order to make sure the final balance is printed correctly we thus sleep for 500ms here.
+    await sleep(1000);
+
     // print balances after swapping
     console.log(
-        "[Maker] Bitcoin balance: %f. Ether balance: %f",
+        "[Maker] Bitcoin balance: %f, Ether balance: %f",
         parseFloat(await maker.bitcoinWallet.getBalance()).toFixed(2),
         parseFloat(
             formatEther(await maker.ethereumWallet.getBalance())

--- a/new_project/examples/separate_apps/src/maker.ts
+++ b/new_project/examples/separate_apps/src/maker.ts
@@ -167,7 +167,7 @@ import { createActor, sleep } from "./lib";
     // The comit network daemon (cnd) processes new incoming blocks faster than etherjs.
     // This results in the final balance not being printed correctly, even though the redeem transaction was already
     // noticed by cnd.
-    // In order to make sure the final balance is printed correctly we thus sleep for 500ms here.
+    // In order to make sure the final balance is printed correctly we thus sleep for 1 second here.
     await sleep(1000);
 
     // print balances after swapping

--- a/new_project/examples/separate_apps/src/taker.ts
+++ b/new_project/examples/separate_apps/src/taker.ts
@@ -2,7 +2,7 @@ import { MakerClient, Order, TakerNegotiator, TryParams } from "comit-sdk";
 import { formatEther } from "ethers/utils";
 import readLineSync from "readline-sync";
 import { toBitcoin } from "satoshi-bitcoin-ts";
-import { createActor } from "./lib";
+import { createActor, sleep } from "./lib";
 
 /**
  * This executable function represents the taker side during a trade.
@@ -138,6 +138,12 @@ import { createActor } from "./lib";
     );
 
     console.log("Swapped!");
+
+    // The comit network daemon (cnd) processes new incoming blocks faster than bcoin.
+    // This results in the final balance not being printed correctly, even though the redeem transaction was already
+    // noticed by cnd.
+    // In order to make sure the final balance is printed correctly we thus sleep for 1 second here.
+    await sleep(1000);
 
     // print balances after swapping
     console.log(

--- a/new_project/examples/separate_apps/src/taker.ts
+++ b/new_project/examples/separate_apps/src/taker.ts
@@ -23,7 +23,7 @@ import { createActor } from "./lib";
 
     // print balances before swapping
     console.log(
-        "[Taker] Bitcoin balance: %f. Ether balance: %f",
+        "[Taker] Bitcoin balance: %f, Ether balance: %f",
         parseFloat(await taker.bitcoinWallet.getBalance()).toFixed(2),
         parseFloat(
             formatEther(await taker.ethereumWallet.getBalance())
@@ -141,7 +141,7 @@ import { createActor } from "./lib";
 
     // print balances after swapping
     console.log(
-        "[Taker] Bitcoin balance: %f. Ether balance: %f",
+        "[Taker] Bitcoin balance: %f, Ether balance: %f",
         parseFloat(await taker.bitcoinWallet.getBalance()).toFixed(2),
         parseFloat(
             formatEther(await taker.ethereumWallet.getBalance())


### PR DESCRIPTION
This PR fixes the Ethers wallet balance printing after swapping. 

The problem of the initial Bcoin wallet balance is not solved through this, check the updated ticket for more infos: https://github.com/comit-network/create-comit-app/issues/140