### PR TITLE
Only mine a block if there is a pending transaction

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -16,6 +16,9 @@ update_configs:
       # version of ethabi depends on web3 version and have to be updated in lockstep
       - match:
           dependency_name: "ethabi"
+      # version of bytes depends on tokio version and have to be updated in lockstep
+      - match:
+          dependency_name: "bytes"
   - package_manager: "javascript"
     directory: "/new_project"
     update_schedule: "daily"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "async-std 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "derive_more 0.99.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "dirs 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "emerald-vault-core 0.26.2 (git+http://github.com/thomaseizinger/emerald-vault.git?branch=create-comit-app-compatible)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.25"
 async-std = "1.2.0"
+bytes = "0.4"
 derive_more = "0.99.2"
 dirs = "2"
 emerald-vault-core = { git = "http://github.com/thomaseizinger/emerald-vault.git", branch = "create-comit-app-compatible", default-features = false }

--- a/src/docker/bitcoin_network_message_codec.rs
+++ b/src/docker/bitcoin_network_message_codec.rs
@@ -1,0 +1,39 @@
+use bytes::{BufMut, BytesMut};
+use rust_bitcoin::{consensus::encode, network::message::RawNetworkMessage};
+use std::io;
+
+pub struct RawNetworkMessageCodec;
+
+impl tokio::codec::Decoder for RawNetworkMessageCodec {
+    type Item = RawNetworkMessage;
+    type Error = encode::Error;
+
+    fn decode(&mut self, src: &mut BytesMut) -> Result<Option<Self::Item>, Self::Error> {
+        match encode::deserialize_partial::<RawNetworkMessage>(&src) {
+            // In this case we just have an incomplete data, so we need to read more
+            Err(encode::Error::Io(ref err)) if err.kind() == io::ErrorKind::UnexpectedEof => {
+                Ok(None)
+            }
+            Err(err) => Err(err),
+            // We have successfully read from the buffer
+            Ok((message, bytes_read)) => {
+                src.advance(bytes_read);
+                Ok(Some(message))
+            }
+        }
+    }
+}
+
+impl tokio::codec::Encoder for RawNetworkMessageCodec {
+    type Item = RawNetworkMessage;
+    type Error = encode::Error;
+
+    fn encode(&mut self, item: Self::Item, dst: &mut BytesMut) -> Result<(), Self::Error> {
+        let bytes = encode::serialize(&item);
+
+        dst.reserve(bytes.len());
+        dst.put(bytes);
+
+        Ok(())
+    }
+}

--- a/src/docker/mod.rs
+++ b/src/docker/mod.rs
@@ -9,6 +9,7 @@ use std::{net::Ipv4Addr, path::Path};
 use tokio::prelude::stream::Stream;
 
 pub mod bitcoin;
+mod bitcoin_network_message_codec;
 pub mod cnd;
 pub mod ethereum;
 mod free_local_port;


### PR DESCRIPTION
Instead of mining a block every second, we only tell the node to mine a block if there is a transaction announcement message.

Still a draft PR because it includes #253.

Fixes #140. (We now produce a lot less blocks, hence the wallet is easily able to keep up with the blockchain.)