### PR TITLE
Remove shiplift host trickery

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,11 +55,8 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
 
-      - name: Install OpenSSL and configure it to link statically
-        run: |
-          vcpkg install openssl:x64-windows-static
-          vcpkg integrate install
-          echo "::set-env name=RUSTFLAGS::-Ctarget-feature=+crt-static"
+      - name: Add strawperryperl to the PATH to override the existing Perl installation so we can compile OpenSSL locally
+        run: echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
         if: matrix.os == 'windows'
 
       - name: Build ${{ matrix.os }} binary

--- a/.github/workflows/release-bin.yml
+++ b/.github/workflows/release-bin.yml
@@ -33,11 +33,8 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
 
-      - name: Install OpenSSL and configure it to link statically
-        run: |
-          vcpkg install openssl:x64-windows-static
-          vcpkg integrate install
-          echo "::set-env name=RUSTFLAGS::-Ctarget-feature=+crt-static"
+      - name: Add strawperryperl to the PATH to override the existing Perl installation so we can compile OpenSSL locally
+        run: echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
         if: matrix.os == 'windows'
 
       - name: Build ${{ matrix.os }} release binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1520,6 +1520,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-src"
+version = "111.6.1+1.1.1d"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.53"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1535,7 @@ dependencies = [
  "autocfg 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "cc 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.65 (registry+https://github.com/rust-lang/crates.io-index)",
+ "openssl-src 111.6.1+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)",
  "pkg-config 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "vcpkg 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -3074,6 +3083,7 @@ dependencies = [
 "checksum once_cell 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "891f486f630e5c5a4916c7e16c4b24a53e78c860b646e9f8e005e4f16847bfed"
 "checksum opaque-debug 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d620c9c26834b34f039489ac0dfdb12c7ac15ccaf818350a64c9b5334a452ad7"
 "checksum openssl 0.10.26 (registry+https://github.com/rust-lang/crates.io-index)" = "3a3cc5799d98e1088141b8e01ff760112bbd9f19d850c124500566ca6901a585"
+"checksum openssl-src 111.6.1+1.1.1d (registry+https://github.com/rust-lang/crates.io-index)" = "c91b04cb43c1a8a90e934e0cd612e2a5715d976d2d6cff4490278a0cddf35005"
 "checksum openssl-sys 0.9.53 (registry+https://github.com/rust-lang/crates.io-index)" = "465d16ae7fc0e313318f7de5cecf57b2fbe7511fd213978b457e1c96ff46736f"
 "checksum parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
 "checksum parking_lot 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fa7767817701cce701d5585b9c4db3cdd02086398322c1d7e8bf5094a96a2ce7"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ web3 = { version = "0.8", default-features = false, features = ["http"] }
 [features]
 default = ["unix"]
 unix = ["shiplift/unix-socket"]
-windows = ["shiplift/tls"]
+windows = ["shiplift/vendored-ssl"]
 
 [build-dependencies]
 anyhow = "1.0.25"


### PR DESCRIPTION
The recent release of shiplift (0.6) contains a patch a takes care of the logic that we previously applied ourselves:
https://github.com/softprops/shiplift/pull/193

@luckysori could you please test this one manually on a Windows machine with docker toolbox?
@D4nte / @bonomat  or @da-kami please test if this still works on Mac.

You can download the binaries from the GitHub actions run here (top right): https://github.com/comit-network/create-comit-app/pull/282/checks?check_run_id=341806523