### PR TITLE
Align examples with current SDK master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Changed
-- Upgrade all examples and new project to `comit-sdk@0.8.0`.
+- Upgrade all examples and new project to `comit-sdk@0.9.0`.
 
 ## [0.6.0] - 2019-12-07
 

--- a/new_project/examples/btc_eth/package.json
+++ b/new_project/examples/btc_eth/package.json
@@ -23,7 +23,7 @@
         "typescript": "^3.7.3"
     },
     "dependencies": {
-        "comit-sdk": "^0.8.0",
+        "comit-sdk": "^0.9.0",
         "dotenv": "^8.2.0",
         "moment": "^2.24.0",
         "satoshi-bitcoin-ts": "^0.2.4"

--- a/new_project/examples/btc_eth/src/index.ts
+++ b/new_project/examples/btc_eth/src/index.ts
@@ -1,9 +1,8 @@
 import {
     Actor,
     BigNumber,
-    BitcoinWallet,
     createActor as createActorSdk,
-    EthereumWallet,
+    EthereumWallet, InMemoryBitcoinWallet,
     SwapRequest,
 } from "comit-sdk";
 import fs from "fs";
@@ -72,7 +71,7 @@ import * as os from "os";
 })();
 
 async function createActor(index: number, name: string): Promise<Actor> {
-    const bitcoinWallet = await BitcoinWallet.newInstance(
+    const bitcoinWallet = await InMemoryBitcoinWallet.newInstance(
         "regtest",
         process.env.BITCOIN_P2P_URI!,
         process.env[`BITCOIN_HD_KEY_${index}`]!
@@ -124,7 +123,7 @@ function createSwap(maker: Actor, taker: Actor): SwapRequest {
 }
 
 function loadEnvironment() {
-    let envFilePath = path.join(os.homedir(), ".create-comit-app", "env");
+    const envFilePath = path.join(os.homedir(), ".create-comit-app", "env");
 
     if (!fs.existsSync(envFilePath)) {
         console.log(
@@ -142,7 +141,7 @@ async function printBalances(actor: Actor) {
     console.log(
         "%s Bitcoin balance: %d. Ether balance: %d",
         actor.name,
-        parseFloat(await actor.bitcoinWallet.getBalance()).toFixed(2),
+        parseFloat((await actor.bitcoinWallet.getBalance()).toString()).toFixed(2),
         toNominal(tokenWei.toString(), 18)
     );
 }

--- a/new_project/examples/btc_eth/src/index.ts
+++ b/new_project/examples/btc_eth/src/index.ts
@@ -2,15 +2,16 @@ import {
     Actor,
     BigNumber,
     createActor as createActorSdk,
-    EthereumWallet, InMemoryBitcoinWallet,
+    EthereumWallet,
+    InMemoryBitcoinWallet,
     SwapRequest,
 } from "comit-sdk";
+import dotenv from "dotenv";
 import fs from "fs";
 import moment from "moment";
-import { toBitcoin, toSatoshi } from "satoshi-bitcoin-ts";
-import * as path from "path";
-import dotenv from "dotenv";
 import * as os from "os";
+import * as path from "path";
+import { toBitcoin, toSatoshi } from "satoshi-bitcoin-ts";
 
 (async function main() {
     loadEnvironment();
@@ -133,7 +134,7 @@ function loadEnvironment() {
         process.exit(1);
     }
 
-    dotenv.config({path: envFilePath});
+    dotenv.config({ path: envFilePath });
 }
 
 async function printBalances(actor: Actor) {
@@ -141,7 +142,9 @@ async function printBalances(actor: Actor) {
     console.log(
         "%s Bitcoin balance: %d. Ether balance: %d",
         actor.name,
-        parseFloat((await actor.bitcoinWallet.getBalance()).toString()).toFixed(2),
+        parseFloat((await actor.bitcoinWallet.getBalance()).toString()).toFixed(
+            2
+        ),
         toNominal(tokenWei.toString(), 18)
     );
 }

--- a/new_project/examples/btc_eth/yarn.lock
+++ b/new_project/examples/btc_eth/yarn.lock
@@ -1141,10 +1141,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comit-sdk@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.8.0.tgz#ac4b64dd69e58f8057d7d96ca52983520011fcf0"
-  integrity sha512-5zn+WZw91I8sShtqeMVKANLu9g4hnWdKndWCdrlnWc6Q+eyx3EWFZ2e1xAxP+WfefxmQ4Ut2t2cgGby7ksSlGA==
+comit-sdk@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.0.tgz#1a8ffceec4a925af99ee4b41fb9fa0943fb5c69c"
+  integrity sha512-Hu0R9lS4aWAZpFm/ScY1LznXnz2cGW0qBPRjDjh0GjEgJu9dTbPdNhxFpqgX5rBppNQyPeM1MNLs8uwbyUgpGg==
   dependencies:
     axios "^0.19.0"
     bcoin "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001"

--- a/new_project/examples/erc20_btc/package.json
+++ b/new_project/examples/erc20_btc/package.json
@@ -22,7 +22,7 @@
         "typescript": "^3.7.3"
     },
     "dependencies": {
-        "comit-sdk": "^0.8.0",
+        "comit-sdk": "^0.9.0",
         "dotenv": "^8.1.0",
         "moment": "^2.24.0",
         "readline-sync": "^1.4.10",

--- a/new_project/examples/erc20_btc/src/index.ts
+++ b/new_project/examples/erc20_btc/src/index.ts
@@ -2,16 +2,17 @@ import {
     Actor,
     BigNumber,
     createActor as createActorSdk,
-    EthereumWallet, InMemoryBitcoinWallet,
+    EthereumWallet,
+    InMemoryBitcoinWallet,
     SwapRequest,
 } from "comit-sdk";
+import dotenv from "dotenv";
 import fs from "fs";
 import moment from "moment";
+import * as os from "os";
+import * as path from "path";
 import readLineSync from "readline-sync";
 import { toBitcoin, toSatoshi } from "satoshi-bitcoin-ts";
-import * as path from "path";
-import dotenv from "dotenv";
-import * as os from "os";
 
 (async function main() {
     loadEnvironment();
@@ -150,7 +151,7 @@ function loadEnvironment() {
         process.exit(1);
     }
 
-    dotenv.config({path: envFilePath});
+    dotenv.config({ path: envFilePath });
 }
 
 async function printBalances(actor: Actor) {
@@ -160,7 +161,9 @@ async function printBalances(actor: Actor) {
     console.log(
         "%s Bitcoin balance: %d. Erc20 Token balance: %d",
         actor.name,
-        parseFloat((await actor.bitcoinWallet.getBalance()).toString()).toFixed(2),
+        parseFloat((await actor.bitcoinWallet.getBalance()).toString()).toFixed(
+            2
+        ),
         await actor.ethereumWallet.getErc20Balance(
             process.env.ERC20_CONTRACT_ADDRESS!
         )

--- a/new_project/examples/erc20_btc/src/index.ts
+++ b/new_project/examples/erc20_btc/src/index.ts
@@ -1,9 +1,8 @@
 import {
     Actor,
     BigNumber,
-    BitcoinWallet,
     createActor as createActorSdk,
-    EthereumWallet,
+    EthereumWallet, InMemoryBitcoinWallet,
     SwapRequest,
 } from "comit-sdk";
 import fs from "fs";
@@ -88,7 +87,7 @@ import * as os from "os";
 })();
 
 async function createActor(index: number, name: string): Promise<Actor> {
-    const bitcoinWallet = await BitcoinWallet.newInstance(
+    const bitcoinWallet = await InMemoryBitcoinWallet.newInstance(
         "regtest",
         process.env.BITCOIN_P2P_URI!,
         process.env[`BITCOIN_HD_KEY_${index}`]!
@@ -141,7 +140,7 @@ function createSwap(maker: Actor, taker: Actor): SwapRequest {
 }
 
 function loadEnvironment() {
-    let envFilePath = path.join(os.homedir(), ".create-comit-app", "env");
+    const envFilePath = path.join(os.homedir(), ".create-comit-app", "env");
 
     if (!fs.existsSync(envFilePath)) {
         console.log(
@@ -161,7 +160,7 @@ async function printBalances(actor: Actor) {
     console.log(
         "%s Bitcoin balance: %d. Erc20 Token balance: %d",
         actor.name,
-        parseFloat(await actor.bitcoinWallet.getBalance()).toFixed(2),
+        parseFloat((await actor.bitcoinWallet.getBalance()).toString()).toFixed(2),
         await actor.ethereumWallet.getErc20Balance(
             process.env.ERC20_CONTRACT_ADDRESS!
         )

--- a/new_project/examples/erc20_btc/yarn.lock
+++ b/new_project/examples/erc20_btc/yarn.lock
@@ -519,10 +519,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comit-sdk@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.8.0.tgz#ac4b64dd69e58f8057d7d96ca52983520011fcf0"
-  integrity sha512-5zn+WZw91I8sShtqeMVKANLu9g4hnWdKndWCdrlnWc6Q+eyx3EWFZ2e1xAxP+WfefxmQ4Ut2t2cgGby7ksSlGA==
+comit-sdk@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.0.tgz#1a8ffceec4a925af99ee4b41fb9fa0943fb5c69c"
+  integrity sha512-Hu0R9lS4aWAZpFm/ScY1LznXnz2cGW0qBPRjDjh0GjEgJu9dTbPdNhxFpqgX5rBppNQyPeM1MNLs8uwbyUgpGg==
   dependencies:
     axios "^0.19.0"
     bcoin "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001"

--- a/new_project/examples/separate_apps/package.json
+++ b/new_project/examples/separate_apps/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@types/express": "^4.17.2",
         "axios": "^0.19.0",
-        "comit-sdk": "^0.8.0",
+        "comit-sdk": "^0.9.0",
         "dotenv": "^8.1.0",
         "express": "^4.17.1",
         "moment": "^2.24.0",

--- a/new_project/examples/separate_apps/src/lib.ts
+++ b/new_project/examples/separate_apps/src/lib.ts
@@ -1,4 +1,9 @@
-import { Actor, BitcoinWallet, createActor as createActorSdk, EthereumWallet } from "comit-sdk";
+import {
+    Actor,
+    createActor as createActorSdk,
+    EthereumWallet,
+    InMemoryBitcoinWallet,
+} from "comit-sdk";
 import dotenv from "dotenv";
 import fs from "fs";
 import * as os from "os";
@@ -7,7 +12,7 @@ import * as path from "path";
 export async function createActor(index: number): Promise<Actor> {
     loadEnvironment();
 
-    const bitcoinWallet = await BitcoinWallet.newInstance(
+    const bitcoinWallet = await InMemoryBitcoinWallet.newInstance(
         "regtest",
         process.env.BITCOIN_P2P_URI!,
         process.env[`BITCOIN_HD_KEY_${index}`]!

--- a/new_project/examples/separate_apps/src/maker.ts
+++ b/new_project/examples/separate_apps/src/maker.ts
@@ -24,7 +24,9 @@ import { createActor, sleep } from "./lib";
     // print balances before swapping
     console.log(
         "[Maker] Bitcoin balance: %f, Ether balance: %f",
-        parseFloat(await maker.bitcoinWallet.getBalance()).toFixed(2),
+        parseFloat((await maker.bitcoinWallet.getBalance()).toString()).toFixed(
+            2
+        ),
         parseFloat(
             formatEther(await maker.ethereumWallet.getBalance())
         ).toFixed(2)
@@ -173,7 +175,9 @@ import { createActor, sleep } from "./lib";
     // print balances after swapping
     console.log(
         "[Maker] Bitcoin balance: %f, Ether balance: %f",
-        parseFloat(await maker.bitcoinWallet.getBalance()).toFixed(2),
+        parseFloat((await maker.bitcoinWallet.getBalance()).toString()).toFixed(
+            2
+        ),
         parseFloat(
             formatEther(await maker.ethereumWallet.getBalance())
         ).toFixed(2)

--- a/new_project/examples/separate_apps/yarn.lock
+++ b/new_project/examples/separate_apps/yarn.lock
@@ -574,10 +574,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-comit-sdk@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.8.0.tgz#ac4b64dd69e58f8057d7d96ca52983520011fcf0"
-  integrity sha512-5zn+WZw91I8sShtqeMVKANLu9g4hnWdKndWCdrlnWc6Q+eyx3EWFZ2e1xAxP+WfefxmQ4Ut2t2cgGby7ksSlGA==
+comit-sdk@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.0.tgz#1a8ffceec4a925af99ee4b41fb9fa0943fb5c69c"
+  integrity sha512-Hu0R9lS4aWAZpFm/ScY1LznXnz2cGW0qBPRjDjh0GjEgJu9dTbPdNhxFpqgX5rBppNQyPeM1MNLs8uwbyUgpGg==
   dependencies:
     axios "^0.19.0"
     bcoin "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001"

--- a/new_project/package.json
+++ b/new_project/package.json
@@ -8,7 +8,7 @@
     "start-env": "create-comit-app start-env"
   },
   "dependencies": {
-    "comit-sdk": "^0.8.0",
+    "comit-sdk": "^0.9.0",
     "dotenv": "^8.2.0",
     "readline-sync": "^1.4.10"
   },


### PR DESCRIPTION
Somehow the examples were not aligned with the code of the SDK master. 
Noticed this when I changed some code parts (to negotiate for ERC20 instead of Ether) and when linking had problems. 

Note: still needs the SDK update