### PR TITLE
Cache the target/ folder based on OS, Rust version and dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,11 +35,6 @@ jobs:
       - name: Run linter
         run: make clippy
 
-      - name: Install NodeJS 10.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
-
   build:
     strategy:
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,6 +23,12 @@ jobs:
           toolchain: ${{ env.RUST_TOOLCHAIN }}
           override: true
 
+      - name: Cache ~/.cargo/bin directory
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/bin
+          key: ubuntu-rust-${{ env.RUST_TOOLCHAIN }}-cargo-bin-directory
+
       - name: Check formatting
         run: make check_format
 
@@ -63,6 +69,18 @@ jobs:
       - name: Add strawperryperl to the PATH to override the existing Perl installation so we can compile OpenSSL locally
         run: echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
         if: matrix.os == 'windows'
+
+      - name: Cache target directory
+        uses: actions/cache@v1
+        with:
+          path: target
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-target-directory-${{ hashFiles('Cargo.lock') }}
+
+      - name: Cache ~/.cargo/registry directory
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}
 
       - name: Build ${{ matrix.os }} binary
         run: make build

--- a/.github/workflows/release-bin.yml
+++ b/.github/workflows/release-bin.yml
@@ -37,6 +37,12 @@ jobs:
         run: echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
         if: matrix.os == 'windows'
 
+      - name: Cache .cargo/registry directory
+        uses: actions/cache@v1
+        with:
+          path: ~/.cargo/registry
+          key: ${{ matrix.os }}-rust-${{ env.RUST_TOOLCHAIN }}-cargo-registry-directory-${{ hashFiles('Cargo.lock') }}
+
       - name: Build ${{ matrix.os }} release binary
         run: make release
 


### PR DESCRIPTION
The latest version of @actions/cache bumped the size limit to 2GB which means we can finally utilize the cache to speed up the builds.