### PR TITLE
Remove lockfile check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,9 +34,6 @@ jobs:
         with:
           node-version: '10.x'
 
-      - name: Check lockfiles
-        run: make check_lock_files
-
   build:
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,6 @@ yarn_install_all:
 	(cd ./new_project/examples/erc20_btc; yarn install)
 	(cd ./new_project/examples/separate_apps; yarn install)
 
-check_lock_files: build_debug yarn_install_all
-	(! git status -s | grep -q lock) # If a lock file was changed, this returns 1 otherwise 0
-
 e2e_scripts:
 	./tests/new.sh
 	./tests/start_env.sh


### PR DESCRIPTION
As GitHub Action does not provide the latest yarn version (1.19.1 instead of 1.21.0), we are getting discrepancies when running `yarn install` which causes CI failure that cannot be (easily) resolved.
Removing this check to remove these failures.