### PR TITLE
Release comit-scripts 0.8.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,8 +35,8 @@ jobs:
           override: true
 
       - name: Add strawperryperl to the PATH to override the existing Perl installation so we can compile OpenSSL locally
-        run: echo "##[add-path]C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin"
         if: matrix.os == 'windows'
+        run: cp C:/strawberry/perl/bin/perl.exe C:/Users/runneradmin/.cargo/bin
 
       - name: Cache .cargo/registry directory
         uses: actions/cache@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,21 +115,21 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/create-comit-app')
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          cd .npm
+          cd create/npm
           yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Build comit-scripts package
         if: contains(github.ref, 'comit-scripts')
         run: |
-          cd create/scripts
+          cd scripts/npm
           yarn install
           yarn list
       - name: Release comit-scripts on NPM
         if: startsWith(github.ref, 'refs/tags/comit-scripts')
         run: |
           echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
-          cd .npm
+          cd scripts/npm
           yarn publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 on:
   push:
     branches:
-      - 'release/*'
+      - 'release/**'
     tags:
       - 'comit-scripts-[0-9]+.[0-9]+.[0-9]+'
       - 'create-comit-app-[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,8 @@ on:
     branches:
       - 'release/*'
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - 'comit-scripts-[0-9]+.[0-9]+.[0-9]+'
+      - 'create-comit-app-[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   rust_build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "comit-scripts"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -6,8 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.8.0] - 2020-01-10
+
 ### Changed
 - The booting of a development environment, `start-env`, is now isolated to the `comit-scripts` package.
+Which means that COMIT App should import dev dependency `comit-scripts` instead of `create-comit-app`.
 See `../create/CHANGELOG.md` for historical changes. 
 
-[Unreleased]: https://github.com/comit-network/create-comit-app/master
+[Unreleased]: https://github.com/comit-network/create-comit-app/compare/comit-scripts-0.8.0...HEAD
+[0.8.0]: https://github.com/comit-network/create-comit-app/compare/0.7.0...comit-scripts-0.8.0

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comit-scripts"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["CoBloX developers <team@coblox.tech>"]
 edition = "2018"
 

--- a/scripts/npm/.gitignore
+++ b/scripts/npm/.gitignore
@@ -1,4 +1,4 @@
 *.tar.gz
 node_modules/
-create-comit-app*
+comit-scripts*
 yarn-error.log

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comit-scripts",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "Set up a local development environment for COMIT apps with one command.",
   "main": "main.js",
   "scripts": {


### PR DESCRIPTION
~I'll probably have to do the npm releasing for an RC version locally first so I can then assign the new comit-scripts package to comit-network and hopefully this'll give the CI the right to publish further versions.~

I am guessing whoever owns the npm token will be owner of the package and can then move ownership of comit-rs under comit-network.