### PR TITLE
Release comit-scripts 0.8.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,7 +262,7 @@ dependencies = [
 
 [[package]]
 name = "comit-scripts"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow 1.0.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoin 0.19.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## [0.8.2] - 2020-01-16
+
 ### Fixed
 - `cannot rename` error during start-env has been fixed.
 

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "comit-scripts"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["CoBloX developers <team@coblox.tech>"]
 edition = "2018"
 

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "comit-scripts",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Set up a local development environment for COMIT apps with one command.",
   "main": "./main.js",
   "scripts": {


### PR DESCRIPTION
### Fixed
- `cannot rename` error during start-env has been fixed.