### PR TITLE
Use chain_id for ethereum instead of network string

### DIFF
--- a/create/new_project/demos/btc_eth/package.json
+++ b/create/new_project/demos/btc_eth/package.json
@@ -24,7 +24,7 @@
         "typescript": "^3.7.5"
     },
     "dependencies": {
-        "comit-sdk": "^0.8.0",
+        "comit-sdk": "^0.9.1",
         "dotenv": "^8.2.0",
         "moment": "^2.24.0",
         "satoshi-bitcoin-ts": "^0.2.4"

--- a/create/new_project/demos/btc_eth/src/index.ts
+++ b/create/new_project/demos/btc_eth/src/index.ts
@@ -1,9 +1,8 @@
 import {
     Actor,
     BigNumber,
-    BitcoinWallet,
     createActor as createActorSdk,
-    EthereumWallet,
+    EthereumWallet, InMemoryBitcoinWallet,
     SwapRequest,
 } from "comit-sdk";
 import dotenv from "dotenv";
@@ -72,7 +71,7 @@ import { toBitcoin, toSatoshi } from "satoshi-bitcoin-ts";
 })();
 
 async function createActor(index: number, name: string): Promise<Actor> {
-    const bitcoinWallet = await BitcoinWallet.newInstance(
+    const bitcoinWallet = await InMemoryBitcoinWallet.newInstance(
         "regtest",
         process.env.BITCOIN_P2P_URI!,
         process.env[`BITCOIN_HD_KEY_${index}`]!
@@ -103,7 +102,7 @@ function createSwap(maker: Actor, taker: Actor): SwapRequest {
         },
         beta_ledger: {
             name: "ethereum",
-            network: "regtest",
+            chain_id: 17,
         },
         alpha_asset: {
             name: "bitcoin",
@@ -139,10 +138,11 @@ function loadEnvironment() {
 
 async function printBalances(actor: Actor) {
     const tokenWei = await actor.ethereumWallet.getBalance();
+    const bitcoinBalance = await actor.bitcoinWallet.getBalance();
     console.log(
         "%s Bitcoin balance: %d. Ether balance: %d",
         actor.name,
-        parseFloat(await actor.bitcoinWallet.getBalance()).toFixed(2),
+        bitcoinBalance.toFixed(2),
         toNominal(tokenWei.toString(), 18)
     );
 }

--- a/create/new_project/demos/btc_eth/src/index.ts
+++ b/create/new_project/demos/btc_eth/src/index.ts
@@ -2,7 +2,8 @@ import {
     Actor,
     BigNumber,
     createActor as createActorSdk,
-    EthereumWallet, InMemoryBitcoinWallet,
+    EthereumWallet,
+    InMemoryBitcoinWallet,
     SwapRequest,
 } from "comit-sdk";
 import dotenv from "dotenv";

--- a/create/new_project/demos/btc_eth/yarn.lock
+++ b/create/new_project/demos/btc_eth/yarn.lock
@@ -1123,10 +1123,10 @@ comit-scripts@^0.8.2:
     axios "^0.19.0"
     targz "^1.0.1"
 
-comit-sdk@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.8.0.tgz#ac4b64dd69e58f8057d7d96ca52983520011fcf0"
-  integrity sha512-5zn+WZw91I8sShtqeMVKANLu9g4hnWdKndWCdrlnWc6Q+eyx3EWFZ2e1xAxP+WfefxmQ4Ut2t2cgGby7ksSlGA==
+comit-sdk@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.1.tgz#46cdfc8abe3c3b132cb91b1a688beee2ece1ce2e"
+  integrity sha512-RvecE3FFmiKGVXoUTXF0QIm56GIRXn9DlnS2SmI0kcsz/f0nhrPr5nQgdIt9juaGzNoCMMTqJgZmy4ATscMWDg==
   dependencies:
     axios "^0.19.0"
     bcoin "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001"

--- a/create/new_project/demos/erc20_btc/package.json
+++ b/create/new_project/demos/erc20_btc/package.json
@@ -23,7 +23,7 @@
         "typescript": "^3.7.5"
     },
     "dependencies": {
-        "comit-sdk": "^0.9.0",
+        "comit-sdk": "^0.9.1",
         "dotenv": "^8.1.0",
         "moment": "^2.24.0",
         "readline-sync": "^1.4.10",

--- a/create/new_project/demos/erc20_btc/src/index.ts
+++ b/create/new_project/demos/erc20_btc/src/index.ts
@@ -115,7 +115,7 @@ function createSwap(maker: Actor, taker: Actor): SwapRequest {
     return {
         alpha_ledger: {
             name: "ethereum",
-            chain_id: 17
+            chain_id: 17,
         },
         beta_ledger: {
             name: "bitcoin",

--- a/create/new_project/demos/erc20_btc/src/index.ts
+++ b/create/new_project/demos/erc20_btc/src/index.ts
@@ -115,7 +115,7 @@ function createSwap(maker: Actor, taker: Actor): SwapRequest {
     return {
         alpha_ledger: {
             name: "ethereum",
-            network: "regtest",
+            chain_id: 17
         },
         beta_ledger: {
             name: "bitcoin",
@@ -158,13 +158,15 @@ async function printBalances(actor: Actor) {
     // Wait a second to let the Ethereum wallet catch up
     await new Promise(r => setTimeout(r, 1000));
 
+    const bitcoinBalance = await actor.bitcoinWallet.getBalance();
+    const tokenAmount = await actor.ethereumWallet.getErc20Balance(
+        process.env.ERC20_CONTRACT_ADDRESS!
+    );
     console.log(
         "%s Bitcoin balance: %d. Erc20 Token balance: %d",
         actor.name,
-        (await actor.bitcoinWallet.getBalance()).toFixed(2),
-        await actor.ethereumWallet.getErc20Balance(
-            process.env.ERC20_CONTRACT_ADDRESS!
-        )
+        bitcoinBalance.toFixed(2),
+        tokenAmount
     );
 }
 

--- a/create/new_project/demos/erc20_btc/yarn.lock
+++ b/create/new_project/demos/erc20_btc/yarn.lock
@@ -526,10 +526,10 @@ comit-scripts@^0.8.2:
     axios "^0.19.0"
     targz "^1.0.1"
 
-comit-sdk@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.0.tgz#1a8ffceec4a925af99ee4b41fb9fa0943fb5c69c"
-  integrity sha512-Hu0R9lS4aWAZpFm/ScY1LznXnz2cGW0qBPRjDjh0GjEgJu9dTbPdNhxFpqgX5rBppNQyPeM1MNLs8uwbyUgpGg==
+comit-sdk@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.1.tgz#46cdfc8abe3c3b132cb91b1a688beee2ece1ce2e"
+  integrity sha512-RvecE3FFmiKGVXoUTXF0QIm56GIRXn9DlnS2SmI0kcsz/f0nhrPr5nQgdIt9juaGzNoCMMTqJgZmy4ATscMWDg==
   dependencies:
     axios "^0.19.0"
     bcoin "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001"

--- a/create/new_project/examples/btc_eth/package.json
+++ b/create/new_project/examples/btc_eth/package.json
@@ -25,7 +25,7 @@
     "dependencies": {
         "@types/express": "^4.17.2",
         "axios": "^0.19.1",
-        "comit-sdk": "^0.9.0",
+        "comit-sdk": "^0.9.1",
         "dotenv": "^8.1.0",
         "express": "^4.17.1",
         "moment": "^2.24.0",

--- a/create/new_project/examples/btc_eth/src/maker.ts
+++ b/create/new_project/examples/btc_eth/src/maker.ts
@@ -52,7 +52,7 @@ import { createActor, sleep } from "./lib";
             // The network the swap will be executed on.
             ledgers: {
                 bitcoin: { network: "regtest" },
-                ethereum: { network: "regtest" },
+                ethereum: { chain_id: 17 },
             },
         },
         { maxTimeoutSecs: 1000, tryIntervalSecs: 0.1 }

--- a/create/new_project/examples/btc_eth/yarn.lock
+++ b/create/new_project/examples/btc_eth/yarn.lock
@@ -576,10 +576,10 @@ comit-scripts@^0.8.2:
     axios "^0.19.0"
     targz "^1.0.1"
 
-comit-sdk@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.0.tgz#1a8ffceec4a925af99ee4b41fb9fa0943fb5c69c"
-  integrity sha512-Hu0R9lS4aWAZpFm/ScY1LznXnz2cGW0qBPRjDjh0GjEgJu9dTbPdNhxFpqgX5rBppNQyPeM1MNLs8uwbyUgpGg==
+comit-sdk@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/comit-sdk/-/comit-sdk-0.9.1.tgz#46cdfc8abe3c3b132cb91b1a688beee2ece1ce2e"
+  integrity sha512-RvecE3FFmiKGVXoUTXF0QIm56GIRXn9DlnS2SmI0kcsz/f0nhrPr5nQgdIt9juaGzNoCMMTqJgZmy4ATscMWDg==
   dependencies:
     axios "^0.19.0"
     bcoin "https://github.com/bcoin-org/bcoin#2496acc7a98a43f00a7b5728eb256877c1bbf001"

--- a/create/new_project/package.json
+++ b/create/new_project/package.json
@@ -8,7 +8,7 @@
     "start-env": "comit-scripts start-env"
   },
   "dependencies": {
-    "comit-sdk": "^0.9.0",
+    "comit-sdk": "^0.9.1",
     "dotenv": "^8.2.0",
     "readline-sync": "^1.4.10"
   },

--- a/scripts/CHANGELOG.md
+++ b/scripts/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+- `chain_id`: for Ethereum we now use `chain_id` instead of a string naming the network. 
+
 ## [0.8.2] - 2020-01-16
 
 ### Fixed

--- a/scripts/src/docker/cnd.rs
+++ b/scripts/src/docker/cnd.rs
@@ -31,7 +31,7 @@ pub async fn new_instance(index: u32) -> anyhow::Result<CndInstance> {
             node_url: "http://bitcoin:18443".to_string(),
         },
         ethereum: Ethereum {
-            network: String::from("regtest"),
+            chain_id: 17,
             node_url: "http://ethereum:8545".to_string(),
         },
         ..Default::default()
@@ -112,7 +112,7 @@ struct Bitcoin {
 
 #[derive(Clone, Debug, serde::Serialize)]
 struct Ethereum {
-    network: String,
+    chain_id: i8,
     node_url: String,
 }
 
@@ -171,7 +171,7 @@ impl Default for Bitcoin {
 impl Default for Ethereum {
     fn default() -> Self {
         Ethereum {
-            network: "regtest".to_string(),
+            chain_id: 17,
             node_url: "http://localhost:8545".to_string(),
         }
     }


### PR DESCRIPTION
Resolves #119  

Note: our examples did not run, hence, I had to upgrade the comit-sdk to the latest version as well. 

Note: 
Once this is done, we can remove the deprecated API from cnd in https://github.com/comit-network/comit-rs/issues/1580