### PR TITLE
Fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,8 +38,8 @@ install_tomlfmt: install_rust
 ## User install
 
 install:
-	$(CARGO) install --force --path create-comit-app $(INSTALL_ARGS)
-	$(CARGO) install --force --path comit-scripts $(INSTALL_ARGS)
+	$(CARGO) install --force --path create $(INSTALL_ARGS)
+	$(CARGO) install --force --path scripts $(INSTALL_ARGS)
 
 clean:
 	$(CARGO) clean


### PR DESCRIPTION
Change the name of the crates specified in the Makefile to
the actual crate names in the cargo workspace.

Closes #532