### PR TITLE
[comit-scripts] Upgrade bitcoind and env file printing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,7 @@ dependencies = [
  "shiplift 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.2.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-compat 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1981,6 +1982,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.33 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "thread_local"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2851,6 +2870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tar 0.4.29 (registry+https://github.com/rust-lang/crates.io-index)" = "c8a4c1d0bee3230179544336c15eefb563cf0302955d962e456542323e8c2e8a"
 "checksum tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e24d9338a0a5be79593e2fa15a648add6138caa803e2d5bc782c371732ca9"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+"checksum thiserror 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "7dfdd070ccd8ccb78f4ad66bf1982dc37f620ef696c6b5028fe2ed83dd3d0d08"
+"checksum thiserror-impl 1.0.20 (registry+https://github.com/rust-lang/crates.io-index)" = "bd80fc12f73063ac132ac92aceea36734f04a1d93c1240c6944e23a3b8841793"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum thread_local 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d40c6d1b69745a6ec6fb1ca717914848da4b44ae29d9b3080cbee91d72a69b14"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"

--- a/scripts/Cargo.toml
+++ b/scripts/Cargo.toml
@@ -25,6 +25,7 @@ serde_json = "1"
 shiplift = { version = "0.6", default-features = false }
 structopt = "0.3"
 tempfile = "3.1.0"
+thiserror = "1"
 tokio = { version = "0.2", features = ["fs", "rt-core", "time", "tcp", "signal"] }
 tokio-compat = "0.1"
 toml = "0.5"

--- a/scripts/src/env/start.rs
+++ b/scripts/src/env/start.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use envfile::EnvFile;
 
+use crate::docker::bitcoin::{DerivationPath, PASSWORD, USERNAME};
 use crate::{
     docker::{
         self,
@@ -76,6 +77,15 @@ pub async fn execute() -> anyhow::Result<Environment> {
         &format!("{}", bitcoind.account_1.master),
     );
     envfile.update("BITCOIN_P2P_URI", &bitcoind.p2p_uri.to_string());
+    envfile.update("BITCOIN_HTTP_URI", &bitcoind.http_endpoint.to_string());
+    envfile.update("BITCOIN_USERNAME", USERNAME);
+    envfile.update("BITCOIN_PASSWORD", PASSWORD);
+    envfile.update(
+        "BITCOIN_DERIVATION_PATH",
+        &*DerivationPath::bip44_bitcoin_testnet()
+            .expect("can create derivation path")
+            .to_string(),
+    );
 
     envfile.update("HTTP_URL_CND_0", &cnd_0.http_endpoint.to_string());
     envfile.update("HTTP_URL_CND_1", &cnd_1.http_endpoint.to_string());

--- a/scripts/src/env/start.rs
+++ b/scripts/src/env/start.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use envfile::EnvFile;
 
-use crate::docker::bitcoin::{DerivationPath, PASSWORD, USERNAME};
+use crate::docker::bitcoin::{PASSWORD, USERNAME};
 use crate::{
     docker::{
         self,
@@ -68,24 +68,12 @@ pub async fn execute() -> anyhow::Result<Environment> {
     );
     envfile.update("ETHEREUM_NODE_HTTP_URL", &parity.http_endpoint.to_string());
 
-    envfile.update(
-        "BITCOIN_HD_KEY_0",
-        &format!("{}", bitcoind.account_0.master),
-    );
-    envfile.update(
-        "BITCOIN_HD_KEY_1",
-        &format!("{}", bitcoind.account_1.master),
-    );
+    envfile.update("BITCOIN_WALLET_0", &bitcoind.account_0.to_string());
+    envfile.update("BITCOIN_WALLET_1", &bitcoind.account_1.to_string());
     envfile.update("BITCOIN_P2P_URI", &bitcoind.p2p_uri.to_string());
     envfile.update("BITCOIN_HTTP_URI", &bitcoind.http_endpoint.to_string());
     envfile.update("BITCOIN_USERNAME", USERNAME);
     envfile.update("BITCOIN_PASSWORD", PASSWORD);
-    envfile.update(
-        "BITCOIN_DERIVATION_PATH",
-        &*DerivationPath::bip44_bitcoin_testnet()
-            .expect("can create derivation path")
-            .to_string(),
-    );
 
     envfile.update("HTTP_URL_CND_0", &cnd_0.http_endpoint.to_string());
     envfile.update("HTTP_URL_CND_1", &cnd_1.http_endpoint.to_string());

--- a/scripts/src/env/start.rs
+++ b/scripts/src/env/start.rs
@@ -1,11 +1,10 @@
 use anyhow::Context;
 use envfile::EnvFile;
 
-use crate::docker::bitcoin::{PASSWORD, USERNAME};
 use crate::{
     docker::{
         self,
-        bitcoin::{self, BitcoindInstance},
+        bitcoin::{self, BitcoindInstance, PASSWORD, USERNAME},
         cnd::{self, CndInstance},
         ethereum::{self, ParityInstance},
     },


### PR DESCRIPTION
Use `generatetoaddress` instead of `generate`.
Print wallet descriptor to `env` file instead of extended-priv-key.

This is needed to proceed with the Taker-UI.