### PR TITLE
Revert paths to start from project head

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
 
           # We need to do bash -c to make sure this also works on GitBash for Windows.
           # GitHub actions uses GitBash for Windows if we say 'shell: bash' on a Windows executor.
-          ARCHIVE=$(bash -c "node dist/print_archive_name.js ${VERSION}")
+          ARCHIVE=$(bash -c "node create/npm/dist/print_archive_name.js ${VERSION}")
 
           tar czvf ${ARCHIVE} -C target/release create-comit-app${{ matrix.binary-suffix }}
 
@@ -86,7 +86,7 @@ jobs:
 
           # We need to do bash -c to make sure this also works on GitBash for Windows.
           # GitHub actions uses GitBash for Windows if we say 'shell: bash' on a Windows executor.
-          ARCHIVE=$(bash -c "node dist/print_archive_name.js ${VERSION}")
+          ARCHIVE=$(bash -c "node scripts/npm/dist/print_archive_name.js ${VERSION}")
 
           tar czvf ${ARCHIVE} -C target/release comit-scripts${{ matrix.binary-suffix }}
 


### PR DESCRIPTION
Changing these paths to be relative was wrong, the `cd` command above is in brackets, meaning it only applies within that context.