### PR TITLE
Bitcoin comit-scripts wallet for funding and block generation

### DIFF
--- a/scripts/src/env/mod.rs
+++ b/scripts/src/env/mod.rs
@@ -8,7 +8,7 @@ use tokio::time::delay_for;
 
 use crate::{
     docker::{
-        bitcoin::{self, BitcoindHttpEndpoint},
+        bitcoin::{self, BitcoindComitScriptsHttpWalletEndpoint},
         delete_container, delete_network,
     },
     print_progress,
@@ -32,7 +32,7 @@ pub async fn start() {
 
     match result {
         Ok(Either::Left((self::start::Environment { bitcoind, .. }, ctrl_c))) => {
-            tokio::spawn(new_miner(bitcoind.http_endpoint));
+            tokio::spawn(new_miner(bitcoind.comit_scripts_wallet_endpoint));
 
             let _ = ctrl_c.await;
         }
@@ -47,10 +47,10 @@ pub async fn start() {
     println!("✓");
 }
 
-async fn new_miner(endpoint: BitcoindHttpEndpoint) -> anyhow::Result<()> {
+async fn new_miner(endpoint: BitcoindComitScriptsHttpWalletEndpoint) -> anyhow::Result<()> {
     loop {
         delay_for(Duration::from_secs(1)).await;
-        bitcoin::mine_a_block(endpoint).await?;
+        bitcoin::mine_a_block(&endpoint.to_string()).await?;
     }
 }
 


### PR DESCRIPTION
Create a wallet specifically for comit-scripts that is used for initial funding and periodically generating blocks (simulated mining).
Without a wallet the simulated mining (block generation every 1 secs) will fail, because it now uses `getnewaddress` and `generatetoaddress`.

Favored using a specific wallet over the default wallet, because it is more resilient against changes.